### PR TITLE
Add Jekyll blog post layout with navigation and styling

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,60 @@
+---
+layout: default
+---
+
+<article class="blog-post">
+
+<header class="post-header">
+    <h1 class="post-title">{{ page.title }}</h1>
+
+    <div class="post-meta">
+        <time datetime="{{ page.date | date_to_xmlschema }}">
+            {{ page.date | date: "%d %B %Y" }}
+        </time>
+
+        {% if page.author %}
+        <span class="post-author"> by {{ page.author }}</span>
+        {% endif %}
+
+        {% if page.categories %}
+        <span class="post-categories">
+            in
+            {% for category in page.categories %}
+            <a href="/blog/category/{{ category | slugify }}">
+                {{ category }}
+            </a>{% unless forloop.last %}, {% endunless %}
+            {% endfor %}
+        </span>
+        {% endif %}
+    </div>
+</header>
+
+<div class="post-content">
+    {{ content }}
+</div>
+
+<footer class="post-footer">
+
+<nav class="post-navigation">
+
+<div class="nav-previous">
+{% if page.previous %}
+<a href="{{ page.previous.url }}" rel="prev">
+← {{ page.previous.title }}
+</a>
+{% endif %}
+</div>
+
+<div class="nav-next">
+{% if page.next %}
+<a href="{{ page.next.url }}" rel="next">
+{{ page.next.title }} →
+</a>
+{% endif %}
+</div>
+
+</nav>
+
+</footer>
+
+</article>

--- a/styles.css
+++ b/styles.css
@@ -420,3 +420,54 @@ a:hover, a:active {
 		border-radius: 8px 0px 0px 8px;
 	}
 }
+
+/* Blog Post Styles */
+
+.blog-post {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 120px 20px 40px 20px;
+}
+
+.post-header {
+    margin-bottom: 1.5rem;
+}
+
+.post-title {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    color: #fff;
+}
+
+.post-meta {
+    font-size: 0.9rem;
+    color: rgba(255,255,255,0.7);
+    margin-bottom: 1.5rem;
+}
+
+.post-content {
+    line-height: 1.7;
+    color: #fff;
+}
+
+.post-content p {
+    margin-bottom: 1rem;
+}
+
+.post-content h2,
+.post-content h3 {
+    margin-top: 1.8rem;
+}
+
+.post-content img {
+    max-width: 100%;
+    height: auto;
+}
+
+.post-navigation {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(255,255,255,0.2);
+}


### PR DESCRIPTION
## Description
This PR introduces a new Jekyll layout `post.html` for rendering individual blog posts on the Thunder Engine website.

## Changes
- Added `_layouts/post.html` layout for blog posts
- Implemented title, publication date, optional author, and categories
- Added previous and next post navigation
- Added styling for blog components in `styles.css`
- Ensured the layout inherits from `default.html` to keep the existing header and footer structure

## Result
Blog posts using `layout: post` will now display:
- Post title
- Publication date
- Optional author
- Categories
- Main content
- Navigation between posts

The styling follows the existing site design and remains responsive.